### PR TITLE
Fix startup error spam: empty point list during initialization

### DIFF
--- a/bacnet_client.js
+++ b/bacnet_client.js
@@ -36,6 +36,7 @@ class BacnetClient extends EventEmitter {
     that.manualMutex = new Mutex();
     that.pollInProgress = false;
     that.buildJsonInProgress = false;
+    that.cacheLoaded = false;
     that.scanMatrix = [];
     that.renderListCount = 0;
     that.portRangeMatrix = config.portRangeMatrix;
@@ -80,6 +81,8 @@ class BacnetClient extends EventEmitter {
 
         //query device task
         const queryDevices = new Task("simple task", () => {
+          if (!that.cacheLoaded) return;
+
           if (!that.pollInProgress && that.enable_device_discovery) {
             that.queryDevices();
           }
@@ -194,22 +197,26 @@ class BacnetClient extends EventEmitter {
 
   async readCachedFile() {
     let that = this;
-    if (that.config.cacheFileEnabled) {
-      const cachedData = await Read_Config_Async();
-      const parsedData = JSON.parse(cachedData);
-      if (parsedData && typeof parsedData == "object") {
-        // renderList is no longer cached - will be rebuilt by tree builder
-        // if (parsedData.renderList) that.renderList = parsedData.renderList;
-        if (parsedData.deviceList) {
-          parsedData.deviceList.forEach(function (device) {
-            let newBacnetDevice = new BacnetDevice(true, device);
-            that.deviceList.push(newBacnetDevice);
-          });
+    try {
+      if (that.config.cacheFileEnabled) {
+        const cachedData = await Read_Config_Async();
+        const parsedData = JSON.parse(cachedData);
+        if (parsedData && typeof parsedData == "object") {
+          // renderList is no longer cached - will be rebuilt by tree builder
+          // if (parsedData.renderList) that.renderList = parsedData.renderList;
+          if (parsedData.deviceList) {
+            parsedData.deviceList.forEach(function (device) {
+              let newBacnetDevice = new BacnetDevice(true, device);
+              that.deviceList.push(newBacnetDevice);
+            });
+          }
+          if (parsedData.pointList) that.networkTree = parsedData.pointList;
+          // renderListCount is no longer cached - will be recalculated by tree builder
+          // if (parsedData.renderListCount) that.renderListCount = parsedData.renderListCount;
         }
-        if (parsedData.pointList) that.networkTree = parsedData.pointList;
-        // renderListCount is no longer cached - will be recalculated by tree builder
-        // if (parsedData.renderListCount) that.renderListCount = parsedData.renderListCount;
       }
+    } finally {
+      that.cacheLoaded = true;
     }
   }
 
@@ -674,6 +681,8 @@ class BacnetClient extends EventEmitter {
 
       // //query device task
       const queryDevices = new Task("simple task", () => {
+        if (!that.cacheLoaded) return;
+
         if (!that.pollInProgress && that.enable_device_discovery) {
           that.queryDevices();
         }
@@ -1938,7 +1947,7 @@ class BacnetClient extends EventEmitter {
       const promiseArray = [];
 
       if (typeof pointList === "undefined" || pointList.length === 0) {
-        throw new Error("Unable to build network tree, empty point list");
+        return { deviceList: this.deviceList, pointList: this.networkTree };
       }
 
       for (const point of pointList) {


### PR DESCRIPTION
## Summary
- `buildJsonObject()` now returns early instead of throwing when a device has no points yet — this is a normal transient state on startup, not an error
- Added a `cacheLoaded` guard so scheduled `queryDevices`/`buildJsonTree` tasks wait until `readCachedFile()` completes before running
- Applied the same guard in `reinitializeClient()` which has the same scheduled task pattern

Fixes #34

## Test plan
- [ ] Start Node-RED with cached BACnet devices — console should no longer show "Unable to build network tree, empty point list" errors
- [ ] Verify devices still populate in the Read node UI tree after startup
- [ ] Verify point polling works normally after the initial discovery period
- [ ] Test with cache file disabled — behaviour should be unchanged