### PR TITLE
Fix boolean write failures with auto application tag detection

### DIFF
--- a/bacnet_client.js
+++ b/bacnet_client.js
@@ -1559,10 +1559,14 @@ class BacnetClient extends EventEmitter {
           port: device.getPort(),
         };
 
+        let objectType = point.meta.objectId.type;
+        let resolvedAppTag = that._resolveAppTag(objectType, options.appTag);
+        let resolvedValue = that._coerceWriteValue(value, resolvedAppTag);
+
         let writeObject = {
           address: addressObject,
           objectId: {
-            type: point.meta.objectId.type,
+            type: objectType,
             instance: point.meta.objectId.instance,
           },
           values: {
@@ -1572,8 +1576,8 @@ class BacnetClient extends EventEmitter {
             },
             value: [
               {
-                type: options.appTag,
-                value: value,
+                type: resolvedAppTag,
+                value: resolvedValue,
               },
             ],
           },
@@ -1606,7 +1610,8 @@ class BacnetClient extends EventEmitter {
           point.options,
           (err, value) => {
             if (err) {
-              that.logOut(err);
+              let objType = that.getObjectType(point.objectId.type) || point.objectId.type;
+              that.logOut("writeProperty error for " + objType + ":" + point.objectId.instance + " - ", err);
             }
           }
         );
@@ -2273,6 +2278,40 @@ class BacnetClient extends EventEmitter {
           //Return circle for all other types
           return "pi readPointIcon";
       }
+    }
+  }
+
+  _resolveAppTag(objectType, userAppTag) {
+    // If user explicitly set an app tag (not auto), use it
+    if (userAppTag !== -1) return userAppTag;
+
+    // Auto-detect based on BACnet object type
+    switch (objectType) {
+      case 3:  // BI
+      case 4:  // BO
+      case 5:  // BV
+        return 9; // ENUMERATED
+      case 13: // MI
+      case 14: // MO
+      case 19: // MV
+        return 2; // UNSIGNED_INT
+      default:
+        return 4; // REAL
+    }
+  }
+
+  _coerceWriteValue(value, appTag) {
+    switch (appTag) {
+      case 9: // ENUMERATED - binary objects expect 0 (inactive) or 1 (active)
+        if (value === true || value === 1 || value === "1" ||
+            value === "true" || value === "active" || value === "on") {
+          return 1;
+        }
+        return 0;
+      case 2: // UNSIGNED_INT - multistate objects expect positive integers
+        return parseInt(value) || 0;
+      default:
+        return value;
     }
   }
 

--- a/bacnet_write.html
+++ b/bacnet_write.html
@@ -8,7 +8,7 @@
     color: "#00aeef",
     defaults: {
       name: { value: "" },
-      applicationTag: { value: "4" },
+      applicationTag: { value: "-1" },
       priority: { value: "16" },
       pointsToWrite: { value: [] },
       writeDevices: { value: [] },
@@ -943,6 +943,7 @@
           ><i class="icon-tag"></i><span data-i18n="bitpool-bacnet.label.applicationTag"></span> Application Tag</label
         >
         <select id="node-input-applicationTag">
+          <option value="-1">AUTO</option>
           <option value="0">NULL</option>
           <option value="1">BOOLEAN</option>
           <option value="2">UNSIGNED_INT</option>


### PR DESCRIPTION
## Summary

- Adds AUTO application tag mode that resolves the correct BACnet application tag per point based on object type: ENUMERATED (9) for binary objects (BI/BO/BV), UNSIGNED_INT (2) for multistate objects (MI/MO/MV), and REAL (4) for analog and other types
- Coerces write values to match the resolved tag — binary points accept `true`, `1`, `"on"`, `"active"` and convert to 0/1; multistate points are parsed as integers
- AUTO is the new default for new write nodes; existing nodes with an explicit tag selection are unaffected
- Improves write error logging to include the object type and instance for easier debugging

## Test plan

- [ ] Deploy to a device with binary outputs (BO/BV) and verify writes succeed with AUTO tag
- [ ] Verify analog output writes still work with AUTO tag
- [ ] Verify multistate output writes work with AUTO tag
- [ ] Verify existing write nodes with explicit tag (e.g. REAL) still behave as before
- [ ] Verify write errors now log the object type and instance in the message
- [ ] Test value coercion: send `true`, `1`, `"on"`, `"active"` to binary points and confirm they resolve to 1
- [ ] Test value coercion: send `false`, `0`, `"off"` to binary points and confirm they resolve to 0

Fixes #33