### PR TITLE
Fix missing point properties on initial device scan

### DIFF
--- a/bacnet_client.js
+++ b/bacnet_client.js
@@ -1944,11 +1944,10 @@ class BacnetClient extends EventEmitter {
       for (const point of pointList) {
         await requestMutex.acquire();
         let result;
+        result = await this._readObjectFull(device, point.value.type, point.value.instance);
+
         if (device.getIsInitialQuery()) {
-          result = await this._readObjectLite(device, point.value.type, point.value.instance);
           device.setIsInitialQuery(false);
-        } else {
-          result = await this._readObjectFull(device, point.value.type, point.value.instance);
         }
 
         if (!result.error) {


### PR DESCRIPTION
## Summary

- Always use `_readObjectFull` in `buildJsonObject` instead of `_readObjectLite` for the first point of newly discovered devices
- This ensures all points have complete properties (description, stateTextArray, objectType, hasPriorityArray) from the very first scan cycle
- Multistate objects (MI/MO/MV) now get their presentValue resolved to state text immediately, rather than staying as a raw integer until the next full scan cycle
- The `isInitialQuery` flag is still cleared after the first successful read to maintain existing device state tracking

## Background

`buildJsonObject` previously used `_readObjectLite` (only PRESENT_VALUE + OBJECT_NAME) for the first point of each new device before switching to `_readObjectFull`. This left points with incomplete data:

- Missing `description`, `stateTextArray`, `objectType`, `hasPriorityArray`
- Multistate `presentValue` reported as raw integer (e.g. `2`) instead of resolved state text (e.g. `"Quiet"`)
- Properties were only recovered on the next full `buildJsonTree` cycle, which could take a long time for large networks

The performance impact is minimal since `_readObjectFull` first tries `PropertyIdentifier.ALL` (single BACnet request) and only falls back to individual property reads on error.

## Test plan

- [ ] Deploy with a device that has multistate objects (MI/MO/MV) and verify stateTextArray and description are populated on first scan
- [ ] Verify presentValue for multistate points shows resolved state text (e.g. "Quiet") instead of raw integer
- [ ] Verify full object output includes objectType, description, stateTextArray, hasPriorityArray
- [ ] Verify no performance regression on networks with many devices

Fixes #32