### PR TITLE
chore: add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,19 @@
+# Repo & CI metadata — not part of the published node
+.github/
+.superpowers/
+docs/
+
+# Tooling / scripts
+*.py
+
+# Dev artifacts (npm ignores .gitignore once this file exists, so restate them)
+node_modules/
+dist/
+coverage/
+test/
+*test.js
+*.log
+.idea/
+.DS_Store
+Thumbs.db
+TEST*.xml


### PR DESCRIPTION
Excludes `.github/`, `docs/`, `.superpowers/`, and `*.py` from the published npm package, and restates the dev-artifact exclusions (npm stops honoring `.gitignore` once an `.npmignore` exists).

Verified via `npm publish --dry-run`: metadata excluded, all node source/locales/resources/examples retained (100 files, 1.6 MB). Pairs with the new publish workflow so the first automated release ships a clean tarball.