### PR TITLE
fix: trigger publish workflow on main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish to npm
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
Default branch renamed master->main. Updates the publish workflow's push trigger to match; no other changes.